### PR TITLE
add exception for metdata records

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -26,4 +26,5 @@ sfdx-source/my_ns_prefix/test/javascript
 sfdx-source/my_ns_prefix/test/selenium
 
 # Ignore all .md files (like README.md)
+!**.md-meta.xml
 **.md


### PR DESCRIPTION
When excluding **.md, the source compare is ignoring the customMetadata records.  Adding an exclusion to allow these records.